### PR TITLE
Add api route to get terms

### DIFF
--- a/data/terms.json
+++ b/data/terms.json
@@ -324,12 +324,12 @@
     "meaning": "A faucet in the web3 world refers to a website, application or any system that gives tokens to its users upon making a request. This token can either be free or awarded for performing certain tasks."
   },
   {
-    "term": "fear of missing out",
-    "meaning": "FOMO is a sensation of worry caused by missing out on a chance. It usually occurs when investors acquire an asset after it has already experienced a significant price increase, hoping to get in and out before a pullback occurs."
-  },
-  {
     "term": "fdv",
     "meaning": "FDV stands for 'Fully diluted Valuation', A token’s FDV refers to the token's market cap once all the tokens have been released. Commonly used by investors in the crypto space when assessing a project"
+  },
+  {
+    "term": "fear of missing out",
+    "meaning": "FOMO is a sensation of worry caused by missing out on a chance. It usually occurs when investors acquire an asset after it has already experienced a significant price increase, hoping to get in and out before a pullback occurs."
   },
   {
     "term": "few",

--- a/index.js
+++ b/index.js
@@ -2,12 +2,15 @@ import express from 'express';
 import cors from 'cors';
 import streamTweet from './services/streamTweet.js';
 import dailyTweet from './services/dailyTweet.js';
+import terms from './routes/terms.js';
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use('/', terms);
+
 
 streamTweet();
 dailyTweet();

--- a/routes/terms.js
+++ b/routes/terms.js
@@ -1,0 +1,37 @@
+import express from 'express';
+import readData from '../utils/readData.js';
+
+const router = express.Router();
+
+
+//get all terms
+router.get('/terms', async (req, res) => {
+    const terms = await readData('terms');
+    res.status(200).json(terms);
+});
+
+//get terms with pagination
+router.get('/terms-with-pagination', async (req, res) => {
+    const { page, limit} = req.query;
+    const startIndex = (page - 1) * limit;
+    const endIndex = page * limit;
+    const terms = await readData('terms.json');
+    const results = {};
+    if (endIndex < terms.length) {
+        results.next = {
+            page: parseInt(page) + 1,
+            limit: limit
+        }
+    }
+    if (startIndex > 0) {
+        results.previous = {
+            page: page - 1,
+            limit: limit
+        }
+    }
+    results.results = terms.slice(startIndex, endIndex);
+    res.json(results);
+});
+
+
+export default router;

--- a/web3terms.postman_collection.json
+++ b/web3terms.postman_collection.json
@@ -1,0 +1,56 @@
+{
+	"info": {
+		"_postman_id": "af2504f5-b334-4a70-8541-d2c5d7b19333",
+		"name": "web3terms",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "6238258"
+	},
+	"item": [
+		{
+			"name": "all terms",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3000/terms",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"terms"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get terms with pagination",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3000/terms-with-pagination?page=2&limit=2",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"terms-with-pagination"
+					],
+					"query": [
+						{
+							"key": "page",
+							"value": "2"
+						},
+						{
+							"key": "limit",
+							"value": "2"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
This PR implements the requirements in issue #61 to add an endpoint that returns terms for use in a front-end application.

Please refer to the postman collection for endpoint usage which includes:
>   Endpoint to get all terms 
>   Endpoint to get terms based on pagination i.e page and limit which can be provided in form of a query for a frontend app.
