### PR TITLE
fix: /get to handle req query properly

### DIFF
--- a/controllers/termsController.js
+++ b/controllers/termsController.js
@@ -6,7 +6,11 @@ const getTerms = async (req, res) => {
 
   const { page, limit } = req.query;
 
-  const result = await fetchTerms(page, limit, terms);
+  const result = await fetchTerms(
+    !!+page ? +page : 1,
+    !!+limit ? +limit : 10,
+    terms
+  );
   res.status(200).json(result);
 };
 

--- a/controllers/termsController.js
+++ b/controllers/termsController.js
@@ -7,8 +7,8 @@ const getTerms = async (req, res) => {
   const { page, limit } = req.query;
 
   const result = await fetchTerms(
-    !!+page ? +page : 1,
-    !!+limit ? +limit : 10,
+    +page && +page > 0 ? +page : 1,
+    +limit && +limit > 0 ? +limit : 10,
     terms
   );
   res.status(200).json(result);


### PR DESCRIPTION
# Description

Fixed API route for /get request, which returns invalid `nextPage` as it's expected to return a number, whereas it returns a concatenated string due to the request query not being handled properly. As shown in the screenshot below. 

Expected `"nextPage": 13` instead got `"nextPage": "121"`

![Screenshot 2022-10-06 at 17 16 12](https://user-images.githubusercontent.com/51055890/194367024-8106f7c4-9cf6-49b5-b896-28821f0fd197.png)

Fixes # (issue)
Made a fix to check if the value of the request param if it's a number, then handle the request properly, if not, it should pass a default value as passed in the `fetchTerms` function :
```js
const fetchTerms = async (page = 1, limit = 10, terms) => {
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I ran the sort command to make sure all terms are sorted
- [ ] I have made corresponding changes to the ReadMe
- [x] My changes generate no new warnings
- [x] Existing unit test passes locally with my changes